### PR TITLE
16/improve gitignore files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,9 @@ Thumbs.db
 
 # System Logs
 *.log
+
+# Docker
+*.pid
+*.sock
+logs/
+__docker_cache__/

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,13 @@
-# Global files
-.vscode/
+# Editor and OS
+.vscode/*
+!.vscode/extensions.json
 .idea/
 .DS_Store
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw?
 Thumbs.db
 
 # Environment

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+# Global files
+.vscode/
+.idea/
+.DS_Store
+Thumbs.db
+
+# Environment
+.env
+.env.*
+
+# System Logs
+*.log

--- a/{{cookiecutter.project_slug}}/backend/.gitignore
+++ b/{{cookiecutter.project_slug}}/backend/.gitignore
@@ -1,0 +1,50 @@
+# Python/ Django
+*.pyc
+__pycache__/
+*.pyo
+*.pyd
+*.db
+db.sqlite3
+*.log
+*.pot
+*.mo
+local_settings.py
+
+# Django media/ static files
+media/
+staticfiles/
+static/
+
+# Environment
+.env
+.env.*
+*.env
+*.secret
+secrets.json
+
+# === Virtual Environment ===
+venv/
+.venv/
+env/
+ENV/
+
+# Testing and coverage logs
+.coverage
+htmlcov/
+.tox/
+.pytest_cache/
+nosetests.xml
+coverage.xml
+
+# Local build artifacts
+build/
+dist/
+*.egg-info/
+.eggs/
+
+# Type Checking
+.mypy_cache/
+.dmypy.json
+.pyre/
+.pytype/
+

--- a/{{cookiecutter.project_slug}}/backend/.gitignore
+++ b/{{cookiecutter.project_slug}}/backend/.gitignore
@@ -1,50 +1,216 @@
-# Python/ Django
-*.pyc
+# Byte-compiled / optimized / DLL files
 __pycache__/
-*.pyo
-*.pyd
-*.db
-db.sqlite3
-*.log
-*.pot
-*.mo
-local_settings.py
+*.py[codz]
+*$py.class
 
-# Django media/ static files
-media/
-staticfiles/
-static/
+# C extensions
+*.so
 
-# Environment
-.env
-.env.*
-*.env
-*.secret
-secrets.json
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
 
-# === Virtual Environment ===
-venv/
-.venv/
-env/
-ENV/
+# PyInstaller
+#   Usually these files are written by a python script from a template
+#   before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
 
-# Testing and coverage logs
-.coverage
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
 htmlcov/
 .tox/
-.pytest_cache/
+.nox/
+.coverage
+.coverage.*
+.cache
 nosetests.xml
 coverage.xml
+*.cover
+*.py.cover
+.hypothesis/
+.pytest_cache/
+cover/
 
-# Local build artifacts
-build/
-dist/
-*.egg-info/
-.eggs/
+# Translations
+*.mo
+*.pot
 
-# Type Checking
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+# Pipfile.lock
+
+# UV
+#   Similar to Pipfile.lock, it is generally recommended to include uv.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+# uv.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+# poetry.lock
+# poetry.toml
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#   pdm recommends including project-wide configuration in pdm.toml, but excluding .pdm-python.
+#   https://pdm-project.org/en/latest/usage/project/#working-with-version-control
+# pdm.lock
+# pdm.toml
+.pdm-python
+.pdm-build/
+
+# pixi
+#   Similar to Pipfile.lock, it is generally recommended to include pixi.lock in version control.
+# pixi.lock
+#   Pixi creates a virtual environment in the .pixi directory, just like venv module creates one
+#   in the .venv directory. It is recommended not to include this directory in version control.
+.pixi
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# Redis
+*.rdb
+*.aof
+*.pid
+
+# RabbitMQ
+mnesia/
+rabbitmq/
+rabbitmq-data/
+
+# ActiveMQ
+activemq-data/
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.envrc
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
 .mypy_cache/
 .dmypy.json
+dmypy.json
+
+# Pyre type checker
 .pyre/
+
+# pytype static type analyzer
 .pytype/
 
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#   JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#   be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#   and can be added to the global gitignore or merged into this file.  For a more nuclear
+#   option (not recommended) you can uncomment the following to ignore the entire idea folder.
+# .idea/
+
+# Abstra
+#   Abstra is an AI-powered process automation framework.
+#   Ignore directories containing user credentials, local state, and settings.
+#   Learn more at https://abstra.io/docs
+.abstra/
+
+# Visual Studio Code
+#   Visual Studio Code specific template is maintained in a separate VisualStudioCode.gitignore 
+#   that can be found at https://github.com/github/gitignore/blob/main/Global/VisualStudioCode.gitignore
+#   and can be added to the global gitignore or merged into this file. However, if you prefer, 
+#   you could uncomment the following to ignore the entire vscode folder
+# .vscode/
+
+# Ruff stuff:
+.ruff_cache/
+
+# PyPI configuration file
+.pypirc
+
+# Marimo
+marimo/_static/
+marimo/_lsp/
+__marimo__/
+
+# Streamlit
+.streamlit/secrets.toml

--- a/{{cookiecutter.project_slug}}/frontend/.gitignore
+++ b/{{cookiecutter.project_slug}}/frontend/.gitignore
@@ -1,24 +1,23 @@
-# Logs
-logs
+# Logs and test coverage
+logs/
 *.log
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 pnpm-debug.log*
 lerna-debug.log*
+vite-error.log*
+coverage/
 
-node_modules
-dist
-dist-ssr
+# Local build artifacts
+node_modules/
+dist/
+dist-ssr/
+build/
+.vite/
 *.local
 
-# Editor directories and files
-.vscode/*
-!.vscode/extensions.json
-.idea
-.DS_Store
-*.suo
-*.ntvs*
-*.njsproj
-*.sln
-*.sw?
+# Environment and build cache
+.env
+.env.*
+*.tsbuildinfo


### PR DESCRIPTION
Closes #16 and #20
- Added a root level `.gitignore` for IDE, OS and Docker generated files
- Added backend `.gitignore` and apply python gitignore template
- Moved System/OS related ignore files from `frontend/.gitignore` to root level `.gitignore` for better organisation